### PR TITLE
allow MT for motion actor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ __pycache__
 /gam_g4/gam_g4/*so
 /gam_g4/gam_g4/geant4_data
 /gam_g4/gam_g4/geant4_data_old
+/gam_g4/gam_g4/save
 
 /build_test/
 

--- a/gam_g4/gam_g4/gam_g4.cpp
+++ b/gam_g4/gam_g4/gam_g4.cpp
@@ -245,7 +245,6 @@ void init_GamHitAttributeManager(py::module &);
 
 void init_GamVHitAttribute(py::module &);
 
-
 void init_GamVSource(py::module &);
 
 void init_GamExceptionHandler(py::module &);
@@ -253,6 +252,7 @@ void init_GamExceptionHandler(py::module &);
 void init_GamNTuple(py::module &);
 
 void init_GamHelpers(py::module &);
+
 
 PYBIND11_MODULE(gam_g4, m) {
 

--- a/gam_g4/gam_g4/gam_lib/GamMotionVolumeActor.h
+++ b/gam_g4/gam_g4/gam_lib/GamMotionVolumeActor.h
@@ -22,6 +22,9 @@ public:
 
     virtual ~GamMotionVolumeActor();
 
+    // Called every time a Run is about to starts in the Master (MT only)
+    virtual void PrepareRunToStartMasterAction(int run_id);
+
     // Called every time a Run starts (all threads)
     virtual void BeginOfRunAction(const G4Run *run);
 

--- a/gam_g4/gam_g4/gam_lib/GamSourceManager.h
+++ b/gam_g4/gam_g4/gam_lib/GamSourceManager.h
@@ -15,7 +15,9 @@
 #include <G4UIsession.hh>
 #include <G4Threading.hh>
 #include <G4Cache.hh>
+
 #include "GamVSource.h"
+#include "GamVActor.h"
 
 // Temporary: later option will be used to control the verbosity
 class UIsessionSilent : public G4UIsession {
@@ -53,6 +55,9 @@ public:
 
     // [py side] add a source to manage
     void AddSource(GamVSource *source);
+
+    // [py side] set the list of actors
+    void SetActors(std::vector<GamVActor*> & actors);
 
     // [available on py side] start the simulation, master thread only
     void StartMasterThread();
@@ -100,6 +105,9 @@ public:
 
     // List of managed sources
     std::vector<GamVSource *> fSources;
+
+    // List of actors (for PreRunMaster callback
+    std::vector<GamVActor*> fActors;
 
     // List of run time intervals
     TimeIntervals fSimulationTimes;

--- a/gam_g4/gam_g4/gam_lib/GamVActor.h
+++ b/gam_g4/gam_g4/gam_lib/GamVActor.h
@@ -51,7 +51,7 @@ public:
      * An alternative is to set all thread modifiable variables in a thread_local structure with
      * G4Cache<my_struct> (see for example in G4SingleParticleSource). And merge at the end.
      * (see GamSimulationStatisticsActor).
-     * The second should be faster but I did not really test.
+     * The second should be faster, but I did not really test.
      *
      * Another alternative is to use G4VAccumulable (not fully clear how/when to call Merge() however).
      *
@@ -65,6 +65,9 @@ public:
     // Called by every worker when the simulation is about to end
     // (after last run)
     virtual void EndOfSimulationWorkerAction(const G4Run * /*lastRun*/) {}
+
+    // Called every time a Run is about to starts in the Master (MT only)
+    virtual void PrepareRunToStartMasterAction(int /*run_id*/) {}
 
     // Called every time a Run starts
     virtual void BeginOfRunAction(const G4Run * /*run*/) {}

--- a/gam_g4/gam_g4/gam_lib/pyGamSourceManager.cpp
+++ b/gam_g4/gam_g4/gam_lib/pyGamSourceManager.cpp
@@ -17,6 +17,7 @@ void init_GamSourceManager(py::module &m) {
             .def(py::init())
             .def("AddSource", &GamSourceManager::AddSource)
             .def("Initialize", &GamSourceManager::Initialize)
+            .def("SetActors", &GamSourceManager::SetActors)
             .def("StartMasterThread", [](GamSourceManager *sm) {
                 py::gil_scoped_release release;
                 sm->StartMasterThread();

--- a/gam_gate/Simulation.py
+++ b/gam_gate/Simulation.py
@@ -154,11 +154,11 @@ class Simulation:
 
         # create the RunManager
         if ui.number_of_threads > 1 or ui.force_multithread_mode:
-            log.info(f'Simulation: create G4MTRunManager with {ui.number_of_threads} threads')
+            log.info(f'Simulation: create MTRunManager with {ui.number_of_threads} threads')
             rm = g4.G4MTRunManager()
             rm.SetNumberOfThreads(ui.number_of_threads)
         else:
-            log.info('Simulation: create G4RunManager')
+            log.info('Simulation: create RunManager')
             rm = g4.G4RunManager()
         self.g4_RunManager = rm
         self.g4_RunManager.SetVerboseLevel(ui.g4_verbose_level)
@@ -194,6 +194,7 @@ class Simulation:
 
         # Actors initialization (before the RunManager Initialize)
         self.actor_manager.create_actors(self.action_manager)
+        self.source_manager.initialize_actors(self.actor_manager.actors)
 
         # Initialization
         log.info('Simulation: initialize G4RunManager')

--- a/gam_gate/actor/MotionVolumeActor.py
+++ b/gam_gate/actor/MotionVolumeActor.py
@@ -47,6 +47,3 @@ class MotionVolumeActor(g4.GamMotionVolumeActor, gam.ActorBase):
             gam.fatal(f'Error in actor {ui}. '
                       f'Rotations must be the same length than the number of runs. '
                       f'While it is {len(ui.rotations)} instead of {len(rt)}')
-
-        if self.simulation.user_info.number_of_threads > 1 or self.simulation.user_info.force_multithread_mode:
-            gam.fatal(f'Cannot (yet!) use GamMotionVolumeActor in Multi-threaded mode, sorry.')

--- a/gam_gate/source/SourceManager.py
+++ b/gam_gate/source/SourceManager.py
@@ -102,6 +102,10 @@ class SourceManager:
         if len(self.user_info_sources) == 0:
             gam.warning(f'No source: no particle will be generated')
 
+    def initialize_actors(self, actors):
+        actors = [actors[a] for a in actors]
+        self.g4_master_source_manager.SetActors(actors)
+
     def build(self):
         # create particles table # FIXME in physics ??
         self.particle_table = g4.G4ParticleTable.GetParticleTable()

--- a/gam_tests/src/test031_beta+_spectrum.py
+++ b/gam_tests/src/test031_beta+_spectrum.py
@@ -81,9 +81,12 @@ def add_source(rad):
     source.energy.type = f'{rad}'
     source.position.type = 'point'
     source.direction.type = 'iso'
-    # with real simulation, the activity should be weighted by the total yield
+    """ 
+        WARNING
+        with real simulation, the activity should be weighted by the total yield ! 
+    """
     total_yield = gam.get_rad_yield(rad)
-    source.activity = activity  # * total_yield
+    source.activity = activity  # * total_yield  <--- this should be taken into account in real simulation
     yi = rad_yields[rad]
     t = (total_yield - yi) / yi < tol
     gam.print_test(t, f'Rad {rad} total yield = {total_yield} vs {yi} (tol is {tol})')

--- a/gam_tests/src/test033_rotation_spect_aa_MT.py
+++ b/gam_tests/src/test033_rotation_spect_aa_MT.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import gam_gate as gam
+import contrib.gam_ge_nm670_spect as gam_spect
+import contrib.gam_iec_phantom as gam_iec
+from scipy.spatial.transform import Rotation
+import numpy as np
+
+paths = gam.get_default_test_paths(__file__, '')
+
+# create the simulation
+sim = gam.Simulation()
+
+# main options
+ui = sim.user_info
+ui.g4_verbose = False
+ui.check_volumes_overlap = False
+
+# units
+m = gam.g4_units('m')
+cm = gam.g4_units('cm')
+keV = gam.g4_units('keV')
+mm = gam.g4_units('mm')
+Bq = gam.g4_units('Bq')
+sec = gam.g4_units('second')
+deg = gam.g4_units('deg')
+kBq = 1000 * Bq
+MBq = 1000 * kBq
+
+''' ================================================== '''
+# main parameters
+ui.visu = False
+ui.g4_verbose = False
+ui.visu_verbose = False
+ui.number_of_threads = 2
+"""
+WARNING : it works but it is much slower than mono-thread simulation.
+Indeed, between each run the master synchronize all workers and this requires that
+all workers finish their jobs (hence longer one). 
+Once all threads are synchronized, the geometry is moved. 
+Then only, workers can start their next run.
+
+It is unknown if this MT version can be useful (yet), maybe for very large 
+simulation ?  
+"""
+colli_flag = not ui.visu
+ac = 10 * MBq
+# ac = 100 * Bq
+distance = 15 * cm
+psd = 6.11 * cm
+p = [0, 0, -(distance + psd)]
+''' ================================================== '''
+
+# world size
+world = sim.world
+world.size = [1.5 * m, 1.5 * m, 1.5 * m]
+world.material = 'G4_AIR'
+
+# spect head (debug mode = very small collimator)
+spect1 = gam_spect.add_ge_nm67_spect_head(sim, 'spect1', collimator=colli_flag, debug=False)
+spect1.translation, spect1.rotation = gam.get_transform_orbiting(p, 'x', 180)
+
+# spect head (debug mode = very small collimator)
+spect2 = gam_spect.add_ge_nm67_spect_head(sim, 'spect2', collimator=colli_flag, debug=False)
+spect2.translation, spect2.rotation = gam.get_transform_orbiting(p, 'x', 0)
+
+# physic list
+sim.set_cut('world', 'all', 10 * mm)
+# sim.set_cut('spect1_crystal', 'all', 1 * mm)
+# sim.set_cut('spect2_crystal', 'all', 1 * mm)
+
+# source #1
+sources = []
+source = sim.add_source('Generic', 'source1')
+source.particle = 'gamma'
+source.energy.type = 'mono'
+source.energy.mono = 140.5 * keV
+source.position.type = 'sphere'
+source.position.radius = 2 * mm
+source.position.translation = [0, 0, 20 * mm]
+source.direction.type = 'iso'
+source.direction.acceptance_angle.volumes = ['spect2', 'spect1']
+source.direction.acceptance_angle.intersection_flag = True
+source.direction.acceptance_angle.normal_flag = True
+source.direction.acceptance_angle.normal_vector = [0, 0, -1]
+source.direction.acceptance_angle.normal_tolerance = 10 * deg
+source.activity = ac / ui.number_of_threads
+sources.append(source)
+
+# source #1
+source2 = sim.add_source('Generic', 'source2')
+gam.copy_user_info(source, source2)
+source2.position.radius = 1 * mm
+source2.position.translation = [20 * mm, 0, -20 * mm]
+sources.append(source2)
+
+# add stat actor
+stat = sim.add_actor('SimulationStatisticsActor', 'Stats')
+stat.output = paths.output / 'test033_stats.txt'
+
+# add default digitizer (it is easy to change parameters if needed)
+gam_spect.add_ge_nm670_spect_simplified_digitizer(sim, 'spect1_crystal', paths.output / 'test033_proj_1.mhd')
+gam_spect.add_ge_nm670_spect_simplified_digitizer(sim, 'spect2_crystal', paths.output / 'test033_proj_2.mhd')
+
+# motion of the spect, create also the run time interval
+heads = [spect1, spect2]
+
+# create a list of run (total = 1 second)
+n = 10
+sim.run_timing_intervals = gam.range_timing(0, 1 * sec, n)
+
+for head in heads:
+    motion = sim.add_actor('MotionVolumeActor', f'Move_{head.name}')
+    motion.mother = head.name
+    motion.translations, motion.rotations = \
+        gam.volume_orbiting_transform('x', 0, 180, n, head.translation, head.rotation)
+    motion.priority = 5
+
+# go
+sim.initialize()
+sim.start()
+
+stats = sim.get_actor('Stats')
+print(stats)
+
+s = 0
+for source in sources:
+    s += gam.get_source_skipped_particles(sim, source.name)
+print(f'Skipped particles {s}')
+
+########################
+gam.warning(f'Check skipped')
+ref_skipped = 19695798
+tol = 0.05
+d = abs(ref_skipped - s) / ref_skipped
+is_ok = d < tol
+gam.print_test(is_ok, f'Skipped particles ref={ref_skipped}, get {s} -> {d * 100}% vs tol={tol * 100}%')
+
+########################
+gam.warning(f'Check stats')
+stats_ref = gam.read_stat_file(paths.output_ref / 'test033_stats.txt')
+stats_ref.counts.run_count *= ui.number_of_threads
+is_ok = gam.assert_stats(stats, stats_ref, 0.05) and is_ok
+
+# compare edep map
+gam.warning(f'Check images')
+is_ok = gam.assert_images(paths.output_ref / 'test033_proj_1.mhd',
+                          paths.output / 'test033_proj_1.mhd',
+                          stats, tolerance=45, axis='x') and is_ok
+is_ok = gam.assert_images(paths.output_ref / 'test033_proj_2.mhd',
+                          paths.output / 'test033_proj_2.mhd',
+                          stats, tolerance=45, axis='x') and is_ok
+
+gam.test_ok(is_ok)


### PR DESCRIPTION
Since MotionVolumeActor, the geometry can be moved from run to run (see test030 for example). It works well in mono-thread. 

However, with MT, G4 synchronize all threads (worker) every run and we need to move the geometry only at that exact moment (before workers restart another run), on the master thread only. 

It works but is very slow, much slower than mono-thread, so useless for the moment 😢  