### PR TITLE
Add default parameters to volumes store

### DIFF
--- a/gam_g4/gam_g4/g4_bindings/pyG4LogicalVolumeStore.cpp
+++ b/gam_g4/gam_g4/g4_bindings/pyG4LogicalVolumeStore.cpp
@@ -15,7 +15,7 @@ void init_G4LogicalVolumeStore(py::module &m) {
     py::class_<G4LogicalVolumeStore>(m, "G4LogicalVolumeStore")
 
         .def("GetInstance", &G4LogicalVolumeStore::GetInstance, py::return_value_policy::reference)
-        .def("GetVolume", &G4LogicalVolumeStore::GetVolume)
+        .def("GetVolume", &G4LogicalVolumeStore::GetVolume, py::arg("name"), py::arg("verbose") = false, py::arg("reverse") = false)
 
         // Additional functions, because the store is a vector
         .def("size", [](G4LogicalVolumeStore *r) { return r->size(); })

--- a/gam_g4/gam_g4/g4_bindings/pyG4PhysicalVolumeStore.cpp
+++ b/gam_g4/gam_g4/g4_bindings/pyG4PhysicalVolumeStore.cpp
@@ -17,5 +17,5 @@ void init_G4PhysicalVolumeStore(py::module &m) {
 
         .def("GetInstance", &G4PhysicalVolumeStore::GetInstance,
              py::return_value_policy::reference)
-        .def("GetVolume", &G4PhysicalVolumeStore::GetVolume);
+        .def("GetVolume", &G4PhysicalVolumeStore::GetVolume, py::arg("name"), py::arg("verbose") = false, py::arg("reverse") = false);
 }


### PR DESCRIPTION
Hi, 

I pulled last version of gam gate and when running tests, I stumbled upon this error : 

```python
Running: test004_simple.py                          FAILED !   1.0 s     anonymized/gam_gate/gam_gate/gam_tests/log/test004_simple.py.log
Traceback (most recent call last):
  File "anonymized/gam_gate/gam_gate/gam_tests/src/test004_simple_MT.py", line 69, in <module>
    sim.initialize()
  File "anonymized/gam_gate/gam_gate/gam_gate/Simulation.py", line 198, in initialize
    self.g4_RunManager.Initialize()
  File "anonymized/gam_gate/gam_gate/gam_gate/geometry/VolumeManager.py", line 175, in Construct
    vol.construct(self)
  File "anonymized/gam_gate/gam_gate/gam_gate/geometry/VolumeBase.py", line 67, in construct
    self.construct_physical_volume()
  File "anonymized/gam_gate/gam_gate/gam_gate/geometry/VolumeBase.py", line 97, in construct_physical_volume
    mother_logical = st.GetVolume(self.user_info.mother, False)
TypeError: GetVolume(): incompatible function arguments. The following argument types are supported:
    1. (self: gam_g4.gam_g4.G4LogicalVolumeStore, arg0: gam_g4.gam_g4.G4String, arg1: bool, arg2: bool) -> gam_g4.gam_g4.G4LogicalVolume

Invoked with: <gam_g4.gam_g4.G4LogicalVolumeStore object at 0x7feb40696ab0>, 'world', False
```
I'm not sure of the "source" of the error, if it is because I have very new version of python (3.10) or install problems. Nonetheless, here is a quick fix of the error that enforces default values in python side. 