### PR TITLE
Fix (Logical|Physical)VolumeStore with G4 11.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ __pycache__
 /make-osx.sh
 /gate-experimental-g4-v11
 
+/compile_commands.json
+/.cache/

--- a/gam_g4/CMakeLists.txt
+++ b/gam_g4/CMakeLists.txt
@@ -100,6 +100,9 @@ endif ()
 # correct one on OSX
 #target_link_libraries(gam_g4 PRIVATE pybind11::module ${Geant4_LIBRARIES} Threads::Threads ${ITK_LIBRARIES})
 
+# additional utilities
+target_include_directories(gam_g4 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/utility)
+
 #set(CMAKE_VERBOSE_MAKEFILE on)
 target_link_libraries(gam_g4 PRIVATE pybind11::module ${Geant4_LIBRARIES} Threads::Threads ${ITK_LIBRARIES} fmt::fmt-header-only)
 

--- a/gam_g4/external/utility/ct/functionarity.h
+++ b/gam_g4/external/utility/ct/functionarity.h
@@ -1,0 +1,67 @@
+#ifndef GAMGATE_GAM_G4_EXTERNAL_UTILITY_CT_FUNCTIONARITY_H
+#define GAMGATE_GAM_G4_EXTERNAL_UTILITY_CT_FUNCTIONARITY_H
+
+namespace ct {
+
+template<typename F> struct FunctionArity;
+template<typename Return, typename... Args>
+struct FunctionArity<Return (*)(Args...)> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...)> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) const> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) volatile> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) const volatile> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...)&> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) const &> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) volatile &> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) const volatile &> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...)&&> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) const &&> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) volatile &&> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+template<typename C, typename Return, typename... Args>
+struct FunctionArity<Return (C::*)(Args...) const volatile &&> {
+    static constexpr unsigned value = sizeof...(Args);
+};
+
+template<typename F>
+constexpr auto functionArity(F) {
+    return FunctionArity<F>::value;
+}
+
+}
+
+#endif

--- a/gam_g4/gam_g4/g4_bindings/pyG4LogicalVolumeStore.cpp
+++ b/gam_g4/gam_g4/g4_bindings/pyG4LogicalVolumeStore.cpp
@@ -15,7 +15,11 @@ void init_G4LogicalVolumeStore(py::module &m) {
     py::class_<G4LogicalVolumeStore>(m, "G4LogicalVolumeStore")
 
         .def("GetInstance", &G4LogicalVolumeStore::GetInstance, py::return_value_policy::reference)
-        .def("GetVolume", &G4LogicalVolumeStore::GetVolume)
+        .def("GetVolume", &G4LogicalVolumeStore::GetVolume,
+             py::arg("name"),
+             py::arg("verbose") = true,
+             py::arg("reverseSearch") = false
+        )
 
         // Additional functions, because the store is a vector
         .def("size", [](G4LogicalVolumeStore *r) { return r->size(); })

--- a/gam_g4/gam_g4/g4_bindings/pyG4LogicalVolumeStore.cpp
+++ b/gam_g4/gam_g4/g4_bindings/pyG4LogicalVolumeStore.cpp
@@ -6,24 +6,36 @@
    -------------------------------------------------- */
 
 #include <pybind11/pybind11.h>
+#include <ct/functionarity.h>
 
 namespace py = pybind11;
 
 #include "G4LogicalVolumeStore.hh"
 
 void init_G4LogicalVolumeStore(py::module &m) {
-    py::class_<G4LogicalVolumeStore>(m, "G4LogicalVolumeStore")
+    using pybind11::operator""_a;
 
+    auto g4LogicalVolumeStore = py::class_<G4LogicalVolumeStore>(m, "G4LogicalVolumeStore")
         .def("GetInstance", &G4LogicalVolumeStore::GetInstance, py::return_value_policy::reference)
-        .def("GetVolume", &G4LogicalVolumeStore::GetVolume,
-             py::arg("name"),
-             py::arg("verbose") = true,
-             py::arg("reverseSearch") = false
-        )
-
         // Additional functions, because the store is a vector
         .def("size", [](G4LogicalVolumeStore *r) { return r->size(); })
         .def("Get", [](G4LogicalVolumeStore *r, int i) {
             return (*r)[i];
         }, py::return_value_policy::reference);
+
+    constexpr auto getVolumeArity = ct::functionArity(&G4LogicalVolumeStore::GetVolume);
+    if constexpr(getVolumeArity == 2) {
+      g4LogicalVolumeStore
+          .def("GetVolume", &G4LogicalVolumeStore::GetVolume,
+               "name"_a,
+               "verbose"_a = true
+          );
+    } else if constexpr(getVolumeArity == 3) {
+      g4LogicalVolumeStore
+          .def("GetVolume", &G4LogicalVolumeStore::GetVolume,
+               "name"_a,
+               "verbose"_a = true,
+               "reverseSearch"_a = false
+          );
+    }
 }

--- a/gam_g4/gam_g4/g4_bindings/pyG4PhysicalVolumeStore.cpp
+++ b/gam_g4/gam_g4/g4_bindings/pyG4PhysicalVolumeStore.cpp
@@ -6,16 +6,32 @@
    -------------------------------------------------- */
 
 #include <pybind11/pybind11.h>
+#include <ct/functionarity.h>
 
 namespace py = pybind11;
 
 #include "G4PhysicalVolumeStore.hh"
 
 void init_G4PhysicalVolumeStore(py::module &m) {
+    using pybind11::operator""_a;
 
-    py::class_<G4PhysicalVolumeStore>(m, "G4PhysicalVolumeStore")
-
+    auto g4PhysicalVolumeStore = py::class_<G4PhysicalVolumeStore>(m, "G4PhysicalVolumeStore")
         .def("GetInstance", &G4PhysicalVolumeStore::GetInstance,
-             py::return_value_policy::reference)
-        .def("GetVolume", &G4PhysicalVolumeStore::GetVolume);
+             py::return_value_policy::reference);
+
+    constexpr auto getVolumeArity = ct::functionArity(&G4PhysicalVolumeStore::GetVolume);
+    if constexpr(getVolumeArity == 2) {
+      g4PhysicalVolumeStore
+          .def("GetVolume", &G4PhysicalVolumeStore::GetVolume,
+               "name"_a,
+               "verbose"_a = true
+          );
+    } else if constexpr(getVolumeArity == 3) {
+      g4PhysicalVolumeStore
+          .def("GetVolume", &G4PhysicalVolumeStore::GetVolume,
+               "name"_a,
+               "verbose"_a = true,
+               "reverseSearch"_a = false
+          );
+    }
 }


### PR DESCRIPTION
Geant4 11.0.2 introduced a minor change in the signature of:
- G4LogicalVolumeStore::GetVolume ;
- G4PhysicalVolumeStore::GetVolume.

This change does not affect C++ code as the new parameter is defaulted.
The Python binding now depends on the arity of these functions.